### PR TITLE
Adds rel-me to social links

### DIFF
--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -2,49 +2,49 @@
     {{ if .theme.github_user }}
     <!-- GitHub -->
     <li>
-    <a href="https://github.com/{{ .theme.github_user }}" class="github" title="Github"></a>
+    <a href="https://github.com/{{ .theme.github_user }}" rel="me" class="github" title="Github"></a>
     </li>
     {{ end }}
     {{ if .theme.googleplus_user }}
     <!-- Google Plus -->
     <li>
-    <a href="http://plus.google.com/{{ .theme.googleplus_user }}?rel=author" class="google" title="Google+"></a>
+    <a href="http://plus.google.com/{{ .theme.googleplus_user }}?rel=author" rel="me" class="google" title="Google+"></a>
     </li>
     {{ end }}
     {{ if .theme.facebook_user }}
     <!-- Facebook -->
     <li>
-    <a href="http://www.facebook.com/{{ .theme.facebook_user }}" class="facebook" title="Facebook"></a>
+    <a href="http://www.facebook.com/{{ .theme.facebook_user }}" rel="me" class="facebook" title="Facebook"></a>
     </li>
     {{ end }}
     {{ if .theme.twitter_user }}
     <!-- Twitter -->
     <li>
-    <a href="http://www.twitter.com/{{ .theme.twitter_user }}" class="twitter" title="Twitter"></a>
+    <a href="http://www.twitter.com/{{ .theme.twitter_user }}" rel="me" class="twitter" title="Twitter"></a>
     </li>
     {{ end }}
     {{ if .theme.linkedin_user }}
     <!-- LinkedIn -->
     <li>
-    <a href="http://www.linkedin.com/in/{{ .theme.linkedin_user }}" class="linkedin" title="LinkedIn"></a>
+    <a href="http://www.linkedin.com/in/{{ .theme.linkedin_user }}" rel="me" class="linkedin" title="LinkedIn"></a>
     </li>
     {{ end }}
     {{ if .theme.skype_user }}
     <!-- Skype -->
     <li>
-    <a href="http://myskype.info/{{ .theme.skype_user }}" class="skype" title="Skype"></a>
+    <a href="http://myskype.info/{{ .theme.skype_user }}" rel="me" class="skype" title="Skype"></a>
     </li>
     {{ end }}
     {{ if .theme.youtube_user }}
     <!-- Youtube -->
     <li>
-    <a href="http://youtube.com/user/{{ .theme.youtube_user }}" class="youtube" title="Youtube"></a>
+    <a href="http://youtube.com/user/{{ .theme.youtube_user }}" rel="me" class="youtube" title="Youtube"></a>
     </li>
     {{ end }}
     {{ if .theme.lastfm_user }}
     <!-- LastFM -->
     <li>
-    <a href="http://www.lastfm.com/user/{{ .theme.lastfm_user }}" class="lastfm" title="LastFM"></a>
+    <a href="http://www.lastfm.com/user/{{ .theme.lastfm_user }}" rel="me" class="lastfm" title="LastFM"></a>
     </li>
     {{ end }}
 </ul>


### PR DESCRIPTION
[rel="me"](https://indieweb.org/rel-me) is a commonly used way to show that that two websites or social media accounts are the same, and is used for authentication and proving site ownership in a variety of ways.